### PR TITLE
Get more than one attribute value

### DIFF
--- a/src/gossi/ldap/LdapEntry.php
+++ b/src/gossi/ldap/LdapEntry.php
@@ -50,14 +50,45 @@ class LdapEntry {
 	 * @param String $attribute The given attribute.
 	 * @return String The first value for the given attribute or <code>null</code> if the attribute does not exist. 
 	 */
-	public function get($attribute) {
-		$values = ldap_get_values($this->conn, $this->entry, $attribute);
-		if ($values && $values['count']) {
-			return $values[0];
-		} else {
+	public function getFirst($attribute) {
+        if ($attributes = $this->getAll($attribute)) {
+            return $attributes[0];
+        } else {
 			return null;
 		}
 	}
+
+    /**
+     * Returns all the values for the given attribute
+     *
+     * @param String $attribute The given attribute.
+     * @return array The values for the given attribute or <code>null</code> if the attribute does not exist.
+     */
+    public function getAll($attribute) {
+        $values = ldap_get_values($this->conn, $this->entry, $attribute);
+
+        $allValues = array();
+
+        if ($values && $values['count']) {
+            for ($i = 0; $i < $values['count']; $i++) {
+                $allValues[] = $values[$i];
+            }
+
+            return $allValues;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the first value for the given attribute
+     *
+     * @param String $attribute The given attribute.
+     * @return String The first value for the given attribute or <code>null</code> if the attribute does not exist.
+     */
+    public function get($attribute) {
+        return $this->getFirst($attribute);
+    }
 
 	/**
 	 * Returns the distinguished name for that LDAP entity.

--- a/src/gossi/ldap/LdapEntry.php
+++ b/src/gossi/ldap/LdapEntry.php
@@ -51,44 +51,44 @@ class LdapEntry {
 	 * @return String The first value for the given attribute or <code>null</code> if the attribute does not exist. 
 	 */
 	public function getFirst($attribute) {
-        if ($attributes = $this->getAll($attribute)) {
-            return $attributes[0];
-        } else {
+		if ($attributes = $this->getAll($attribute)) {
+			return $attributes[0];
+		} else {
 			return null;
 		}
 	}
 
-    /**
-     * Returns all the values for the given attribute
-     *
-     * @param String $attribute The given attribute.
-     * @return array The values for the given attribute or <code>null</code> if the attribute does not exist.
-     */
-    public function getAll($attribute) {
-        $values = ldap_get_values($this->conn, $this->entry, $attribute);
+	/**
+	 * Returns all the values for the given attribute
+	 *
+	 * @param String $attribute The given attribute.
+	 * @return array The values for the given attribute or <code>null</code> if the attribute does not exist.
+	 */
+	public function getAll($attribute) {
+		$values = ldap_get_values($this->conn, $this->entry, $attribute);
 
-        $allValues = array();
+		$allValues = array();
 
-        if ($values && $values['count']) {
-            for ($i = 0; $i < $values['count']; $i++) {
-                $allValues[] = $values[$i];
-            }
+		if ($values && $values['count']) {
+			for ($i = 0; $i < $values['count']; $i++) {
+				$allValues[] = $values[$i];
+			}
 
-            return $allValues;
-        } else {
-            return null;
-        }
-    }
+			return $allValues;
+		} else {
+			return null;
+		}
+	}
 
-    /**
-     * Returns the first value for the given attribute
-     *
-     * @param String $attribute The given attribute.
-     * @return String The first value for the given attribute or <code>null</code> if the attribute does not exist.
-     */
-    public function get($attribute) {
-        return $this->getFirst($attribute);
-    }
+	/**
+	 * Returns the first value for the given attribute
+	 *
+	 * @param String $attribute The given attribute.
+	 * @return String The first value for the given attribute or <code>null</code> if the attribute does not exist.
+	 */
+	public function get($attribute) {
+		return $this->getFirst($attribute);
+	}
 
 	/**
 	 * Returns the distinguished name for that LDAP entity.


### PR DESCRIPTION
I need to be able to get all values of an attribute for something I'm working on but noticed that LdapEntry::get() only returns the first.

I've kept the functionality of LdapEntry::get() to return only the first element to stop any BC breaks but added LdapEntry::getFirst() and LdapEntry::getAll().

I'm not completely happy with the method names so feel free to change them if you're happy to merge this.
